### PR TITLE
test: increase default obj pool size

### DIFF
--- a/tests/test_pmemobj_dict.py
+++ b/tests/test_pmemobj_dict.py
@@ -10,7 +10,7 @@ class TestPersistentDict(TestCase):
 
     def _make_dict(self, *args, **kw):
         self.fn = self._test_fn()
-        self.pop = pmemobj.create(self.fn, debug=True)
+        self.pop = pmemobj.create(self.fn, pool_size=32*1024*1024, debug=True)
         self.addCleanup(self.pop.close)
         self.pop.root = self.pop.new(pmemobj.PersistentDict, *args, **kw)
         return self.pop.root


### PR DESCRIPTION
A workaround for failing builds/tests on Travis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pynvm/17)
<!-- Reviewable:end -->
